### PR TITLE
Laid the foundations of the logging framework. Now there is a functio…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 venv/
 past_builds/
 __pycache__
+buildData.dat
+Build*.txt

--- a/ci_server/server.py
+++ b/ci_server/server.py
@@ -1,5 +1,34 @@
 from http.server import BaseHTTPRequestHandler
 
+import time
+
+# The purpose of this function is to generate a unique identifier that serves
+# as the build log name.
+# Note: This would fail if the number of total builds would reach maxint.
+def make_log_title():
+    tob = time.localtime()
+    bString = "X"
+    bDatPath = "../logfiles/buildData.dat"
+    newBuildNum = -1
+
+    # Format the new build number.
+    with open(bDatPath) as f:
+        newBuildNum = int(f.read()[:-1])+1
+
+    # Generate a build log string.
+    bString = f"Build_{newBuildNum}_{tob.tm_year}_{tob.tm_mon}_{tob.tm_mday}_{tob.tm_hour}.txt"
+
+    with open(bDatPath, "w") as f:
+        f.truncate(0)
+        f.write(str(newBuildNum)+'\n')
+
+    return bString
+
+# The purpose of this function is to log the output of the tests and the linting.
+# Creates a new .txt file with the output of the linter and the tests.
+def make_log(lint_output, pytest_output):
+    with open(f"../logfiles/{make_log_title()}", "w") as f:
+        f.write(f"=== LINT OUTPUT ===\n{lint_output}\n\n=== PYTEST OUTPUT ===\n{pytest_output}\n")
 
 class CIServer(BaseHTTPRequestHandler):
     """


### PR DESCRIPTION
…n that create a new logfile with a unique name which hosts the contents of the linter and the tests output. Relates to issue #18.

The core feature here is the make_log function which takes two strings. These strings are then written to a .txt file which can be exposed from the server. The server tracks the total number of builds that have been made. They are logged in the buildData.dat file. Should close #18 .