### PR TITLE
feat: add two tests for the logging functions #40

### DIFF
--- a/ci_server/handler.py
+++ b/ci_server/handler.py
@@ -22,9 +22,12 @@ class CIServerHandler(BaseHTTPRequestHandler):
     Custom HTTP handler that handles post request from webhook on Github.
     """
 
-    def __init__(self, update_commit_status_fn, *args):
+    def __init__(self, update_commit_status_fn, make_log_title_fn, make_log_fn, *args):
         # We assign the function that updates the commit statuses to a class member.
         self.update_commit_status = update_commit_status_fn
+        self.make_log_title = make_log_title_fn
+        self.make_log = make_log_fn
+
         super().__init__(*args)
 
     # GET/POST handler
@@ -159,34 +162,4 @@ class CIServerHandler(BaseHTTPRequestHandler):
         sys.stdout = out # Restore original output stream
         return results
 
-    # LOGGING
-
-    # The purpose of this function is to generate a unique identifier that serves
-    # as the build log name.
-    # Note: This would fail if the number of total builds would reach maxint.
-    def make_log_title(self):
-        tob = time.localtime()
-        bString = "X"
-        bDatPath = "logfiles/buildData.dat"
-        newBuildNum = -1
-
-        # Format the new build number.
-        with open(bDatPath) as f:
-            newBuildNum = int(f.read()[:-1]) + 1
-
-        # Generate a build log string.
-        bString = f"Build_{newBuildNum}_{tob.tm_year}_{tob.tm_mon}_{tob.tm_mday}_{tob.tm_hour}.txt"
-
-        with open(bDatPath, "w") as f:
-            f.truncate(0)
-            f.write(str(newBuildNum) + "\n")
-
-        return bString
-
-    # The purpose of this function is to log the output of the tests and the linting.
-    # Creates a new .txt file with the output of the linter and the tests.
-    def make_log(self, lint_output, pytest_output):
-        with open(f"logfiles/{self.make_log_title()}", "w") as f:
-            f.write(
-                f"=== LINT OUTPUT ===\n{lint_output}\n\n=== PYTEST OUTPUT ===\n{pytest_output}\n"
-            )
+    

--- a/ci_server/server.py
+++ b/ci_server/server.py
@@ -4,6 +4,7 @@ from http.server import HTTPServer
 from dotenv import load_dotenv
 import requests
 from .handler import CIServerHandler
+import time
 
 
 class CIServer:
@@ -48,3 +49,36 @@ class CIServer:
         DATA = {"state": statusString}
         response = requests.post(url=URL, data=json.dumps(DATA), headers=HEADERS)
         print(response)
+
+        # LOGGING
+
+    # The purpose of this function is to generate a unique identifier that serves
+    # as the build log name.
+    # Note: This would fail if the number of total builds would reach maxint.
+    def make_log_title(self):
+        tob = time.localtime()
+        bString = "X"
+        bDatPath = "logfiles/buildData.dat"
+        newBuildNum = -1
+
+        # Format the new build number.
+        with open(bDatPath) as f:
+            newBuildNum = int(f.read()[:-1]) + 1
+
+        # Generate a build log string.
+        bString = f"Build_{newBuildNum}_{tob.tm_year}_{tob.tm_mon}_{tob.tm_mday}_{tob.tm_hour}.txt"
+
+        with open(bDatPath, "w") as f:
+            f.truncate(0)
+            f.write(str(newBuildNum) + "\n")
+
+        return bString
+
+    # The purpose of this function is to log the output of the tests and the linting.
+    # Creates a new .txt file with the output of the linter and the tests.
+    def make_log(self, lint_output, pytest_output):
+        with open(f"logfiles/{self.make_log_title()}", "w") as f:
+            f.write(
+                f"=== LINT OUTPUT ===\n{lint_output}\n\n=== PYTEST OUTPUT ===\n{pytest_output}\n"
+            )
+

--- a/tests/ci_server/log_test.py
+++ b/tests/ci_server/log_test.py
@@ -1,0 +1,31 @@
+import os
+import pytest
+from ci_server.server import CIServer
+import re
+
+server = CIServer("localhost", 8080)
+
+# ------------------------------------
+# Tests for make_log_title()
+# ------------------------------------
+
+# This test checks that the build nr in the log title is the same as the nr 
+# in buildData.dat.
+def test_log_title_build_num():
+    title = server.make_log_title()
+    file = open("logfiles/buildData.dat", "r+")
+    counter = file.read()
+    assert title.split("_")[1] == counter.replace('\n', '')
+
+# This test checks that the content of every log file follows a certain format.
+def test_log_format():
+    server.make_log("line_output", "pytest_output")
+    folder = os.listdir("logfiles")
+    
+    for file_name in folder:
+        if (file_name.split(".")[1] == "dat"):
+            continue
+        file = open("logfiles/" + file_name, "r+")
+        file_content = file.read()
+        assert file_content.__contains__("=== LINT OUTPUT ===")
+        assert file_content.__contains__("=== PYTEST OUTPUT ===")


### PR DESCRIPTION
Created two tests for make_log() and make_log_title() (one test per function). I also moved these functions from handler.py to server.py in order to make it easier to invoke them from the tests.